### PR TITLE
Explicitly mask registry password

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -33,6 +33,13 @@ outputs:
 runs:
   using: composite
   steps:
+
+    - name: Mask Registry Password
+      run: |
+        echo "::add-mask::$REGISTRY_PASSWORD"
+      env:
+        REGISTRY_PASSWORD: ${{ needs.setup.outputs.registry_password }}
+
     - name: Helm | Login
       shell: bash
       run: echo ${{ inputs.registry_password }} | helm registry login -u ${{ inputs.registry_username }} --password-stdin ${{ inputs.registry }}


### PR DESCRIPTION
Currently, 
https://github.com/appany/helm-oci-chart-releaser/blob/a517e1b617d0377cbca9073bd8b0f35daf83059c/action.yaml#L38

exposes the password if `${{ inputs.registry_password }}` is not already masked. This could happen if the input is not a secret (ex: anything other than GITHUB_TOKEN, like AWS_SECRET_ACCESS_KEY passed as an input). Explicitly masking should prevent accidental leaks of the token in output stream