### PR TITLE
Add optional step to update dependencies before package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     registry: ghcr.io
     registry_username: ${{ secrets.REGISTRY_USERNAME }}
     registry_password: ${{ secrets.REGISTRY_PASSWORD }}
+    update_dependencies: 'true' # Defaults to false
 
 # helm pull ghcr.io/appany/my-chart:0.1.0
 ```
@@ -37,6 +38,7 @@
     registry: appany.azurecr.io
     registry_username: ${{ secrets.REGISTRY_USERNAME }}
     registry_password: ${{ secrets.REGISTRY_PASSWORD }}
+    update_dependencies: 'true' # Defaults to false
 
 # helm pull appany.azurecr.io/helm/my-chart:0.1.0
 ```
@@ -66,6 +68,10 @@ inputs:
   registry_password:
     required: true
     description: OCI registry password
+  update_dependencies:
+    required: false
+    default: 'false'
+    description: Update chart dependencies before packaging (Default 'false')
 ```
 
 ## Outputs

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,10 @@ inputs:
   registry_password:
     required: true
     description: OCI registry password
+  update_dependencies:
+    required: false
+    default: 'false'
+    description: Update chart dependencies before packaging (Default 'false')
 outputs:
   image:
     value: ${{ steps.output.outputs.image }}
@@ -36,6 +40,13 @@ runs:
     - name: Helm | Login
       shell: bash
       run: echo ${{ inputs.registry_password }} | helm registry login -u ${{ inputs.registry_username }} --password-stdin ${{ inputs.registry }}
+      env:
+        HELM_EXPERIMENTAL_OCI: '1'
+    
+    - name: Helm | Dependency
+      if: inputs.update_dependencies == 'true'
+      shell: bash
+      run: helm dependency update ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }}
       env:
         HELM_EXPERIMENTAL_OCI: '1'
 


### PR DESCRIPTION
Added a optional step, and input variable to control it, to run `helm dependency update` before package. Default to false to retain prior behaviour for existing users. 