### PR TITLE
feat: allow appVersion to be specified

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -14,6 +14,9 @@ inputs:
   tag:
     required: true
     description: Chart version
+  app_version:
+    required: false
+    description: Set appVersion in the Chart
   path:
     required: false
     description: Chart path (Default 'charts/{name}')
@@ -42,7 +45,7 @@ runs:
       run: echo ${{ inputs.registry_password }} | helm registry login -u ${{ inputs.registry_username }} --password-stdin ${{ inputs.registry }}
       env:
         HELM_EXPERIMENTAL_OCI: '1'
-    
+
     - name: Helm | Dependency
       if: inputs.update_dependencies == 'true'
       shell: bash
@@ -52,7 +55,7 @@ runs:
 
     - name: Helm | Package
       shell: bash
-      run: helm package ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }} --version ${{ inputs.tag }}
+      run: helm package ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }} --version ${{ inputs.tag }} ${{ inputs.app_version != null && format('--app-version {0}', inputs.app_version) || '' }}
       env:
         HELM_EXPERIMENTAL_OCI: '1'
 


### PR DESCRIPTION
Allows the `--app-version` switch to be passed to the `helm package` command.