### PR TITLE
fix: escape args

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ inputs:
     description: OCI registry password
   update_dependencies:
     required: false
-    default: 'false'
+    default: "false"
     description: Update chart dependencies before packaging (Default 'false')
 outputs:
   image:
@@ -42,36 +42,36 @@ runs:
   steps:
     - name: Helm | Login
       shell: bash
-      run: echo ${{ inputs.registry_password }} | helm registry login -u ${{ inputs.registry_username }} --password-stdin ${{ inputs.registry }}
+      run: echo '${{ inputs.registry_password }}' | helm registry login -u '${{ inputs.registry_username }}' --password-stdin '${{ inputs.registry }}'
       env:
-        HELM_EXPERIMENTAL_OCI: '1'
+        HELM_EXPERIMENTAL_OCI: "1"
 
     - name: Helm | Dependency
       if: inputs.update_dependencies == 'true'
       shell: bash
       run: helm dependency update ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }}
       env:
-        HELM_EXPERIMENTAL_OCI: '1'
+        HELM_EXPERIMENTAL_OCI: "1"
 
     - name: Helm | Package
       shell: bash
-      run: helm package ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }} --version ${{ inputs.tag }} ${{ inputs.app_version != null && format('--app-version {0}', inputs.app_version) || '' }}
+      run: helm package '${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }}' --version '${{ inputs.tag }}' ${{ inputs.app_version != null && format('--app-version {0}', inputs.app_version) || '' }}
       env:
-        HELM_EXPERIMENTAL_OCI: '1'
+        HELM_EXPERIMENTAL_OCI: "1"
 
     - name: Helm | Push
       shell: bash
-      run: helm push ${{ inputs.name }}-${{ inputs.tag }}.tgz oci://${{ inputs.registry }}/${{ inputs.repository }}
+      run: helm push '${{ inputs.name }}-${{ inputs.tag }}.tgz' 'oci://${{ inputs.registry }}/${{ inputs.repository }}'
       env:
-        HELM_EXPERIMENTAL_OCI: '1'
+        HELM_EXPERIMENTAL_OCI: "1"
 
     - name: Helm | Logout
       shell: bash
-      run: helm registry logout ${{ inputs.registry }}
+      run: helm registry logout '${{ inputs.registry }}'
       env:
-        HELM_EXPERIMENTAL_OCI: '1'
+        HELM_EXPERIMENTAL_OCI: "1"
 
     - name: Helm | Output
       id: output
       shell: bash
-      run: echo "image=${{ inputs.registry }}/${{ inputs.repository }}/${{ inputs.name }}:${{ inputs.tag }}" >> $GITHUB_OUTPUT
+      run: echo 'image=${{ inputs.registry }}/${{ inputs.repository }}/${{ inputs.name }}:${{ inputs.tag }}' >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -31,7 +31,7 @@ inputs:
     description: OCI registry password
   update_dependencies:
     required: false
-    default: "false"
+    default: 'false'
     description: Update chart dependencies before packaging (Default 'false')
 outputs:
   image:
@@ -44,34 +44,34 @@ runs:
       shell: bash
       run: echo '${{ inputs.registry_password }}' | helm registry login -u '${{ inputs.registry_username }}' --password-stdin '${{ inputs.registry }}'
       env:
-        HELM_EXPERIMENTAL_OCI: "1"
+        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Dependency
       if: inputs.update_dependencies == 'true'
       shell: bash
       run: helm dependency update ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }}
       env:
-        HELM_EXPERIMENTAL_OCI: "1"
+        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Package
       shell: bash
       run: helm package '${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }}' --version '${{ inputs.tag }}' ${{ inputs.app_version != null && format('--app-version {0}', inputs.app_version) || '' }}
       env:
-        HELM_EXPERIMENTAL_OCI: "1"
+        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Push
       shell: bash
       run: helm push '${{ inputs.name }}-${{ inputs.tag }}.tgz' 'oci://${{ inputs.registry }}/${{ inputs.repository }}'
       env:
-        HELM_EXPERIMENTAL_OCI: "1"
+        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Logout
       shell: bash
       run: helm registry logout '${{ inputs.registry }}'
       env:
-        HELM_EXPERIMENTAL_OCI: "1"
+        HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Output
       id: output
       shell: bash
-      run: echo 'image=${{ inputs.registry }}/${{ inputs.repository }}/${{ inputs.name }}:${{ inputs.tag }}' >> $GITHUB_OUTPUT
+      run: echo 'image=${{ inputs.registry }}/${{ inputs.repository }}/${{ inputs.name }}:${{ inputs.tag }}'' >> $GITHUB_OUTPUT

--- a/action.yaml
+++ b/action.yaml
@@ -74,4 +74,4 @@ runs:
     - name: Helm | Output
       id: output
       shell: bash
-      run: echo 'image=${{ inputs.registry }}/${{ inputs.repository }}/${{ inputs.name }}:${{ inputs.tag }}'' >> $GITHUB_OUTPUT
+      run: echo 'image=${{ inputs.registry }}/${{ inputs.repository }}/${{ inputs.name }}:${{ inputs.tag }}' >> $GITHUB_OUTPUT


### PR DESCRIPTION
fixes #14

This PR fixes the OCI action by properly escaping *all* the bash scripts arguments.

The reason for all of these changes is that by default, the popular container registry https://goharbor.io/ produces usernames with `$` in them. Similarly, it may happen to generate passwords that have bash expensions in them.

Escaping every little thing when using the action is painful.

I've tested the fix by replacing the action line in my (private) projects with `Karitham/helm-oci-chart-releaser@f2f293f8f796568f47dfaea603ae61e2b3b3fa41` and it seems to work fine when I finally remove the escaping.

If you used to escape, here are some examples after that fix:

```diff
- key: "'a'"
+ key: "a"
- key: '"a"'
+ key: 'a'
- key: '\$a'
+ key: '$a'
```

With this PR, arguments follow the rules described here: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#2.2:~:text=a%20token%20separator.-,2.2.2%20Single%2DQuotes,-Enclosing%20characters%20in