### PR TITLE
fix: if condition for Helm | Dependency not working

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -47,7 +47,7 @@ runs:
         HELM_EXPERIMENTAL_OCI: '1'
 
     - name: Helm | Dependency
-      if: inputs.update_dependencies == 'true'
+      if: ${{ inputs.update_dependencies == 'true' }}
       shell: bash
       run: helm dependency update ${{ inputs.path == null && format('{0}/{1}', 'charts', inputs.name) || inputs.path }}
       env:


### PR DESCRIPTION
. I noticed that `update_dependencies` was not interpreted correctly in the `Helm | Dependency` steps if condition.
It looks like the correct way to evaluate the condition is to wrap it with `${{ }}`.

see discussion in: https://github.com/actions/runner/issues/1173

see also: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idif

> When you use expressions in an if conditional, you can, optionally, omit the ${{ }} expression syntax because GitHub Actions automatically evaluates the if conditional as an expression. However, this exception does not apply everywhere.